### PR TITLE
enable svg in review avatars

### DIFF
--- a/themes/hugobricks/layouts/partials/reviews.html
+++ b/themes/hugobricks/layouts/partials/reviews.html
@@ -4,7 +4,7 @@
     <li>
         <div class="box">
             <div>
-                <img src="{{ if (resources.GetMatch .image ) }}{{ ((resources.GetMatch .image).Fit `200x200 jpg Smart q50`).RelPermalink | safeURL }}{{ else }}{{ .image }}{{ end }}" alt="{{ .name }} image" class="avatar colorize_image">
+                <img src="{{ if and (resources.GetMatch .image ) (ne (resources.GetMatch .image).MediaType.SubType "svg") }}{{ ((resources.GetMatch .image).Fit `200x200 jpg Smart q50`).RelPermalink | safeURL }}{{ else }}{{ .image }}{{ end }}" alt="{{ .name }} image" class="avatar colorize_image">
                 <div>
                     <h3>{{ .name }}</h3>
                     <div class="function">{{ .function }}</div>


### PR DESCRIPTION
Hi,

I wanted to use country flags in svg format as avatars in the review brick, but the rendering failed.
Therefore I've added this additional condition.