### PR TITLE
Disable search function by default

### DIFF
--- a/data/settings.yaml
+++ b/data/settings.yaml
@@ -11,3 +11,4 @@ show_all_services: true
 preheader: 
   active: true
   is_light: true
+enable_search: false

--- a/themes/hugobricks/layouts/_default/baseof.html
+++ b/themes/hugobricks/layouts/_default/baseof.html
@@ -71,9 +71,11 @@
             <span class="itemcount">0</span>
           </a>
           {{- end -}}
+          {{ if .Site.Data.settings.enable_search }}
           <a href="/search">
             <img src="/img/search.svg" alt="Search icon" class="black_2_textDark" />
           </a>
+          {{- end -}}
           {{- if gt (len .Site.Languages) 1 -}}
           <div class="navnav languages">
             <ul>


### PR DESCRIPTION
Hugobricks enables the search function by default but leads the user to a 404 error page.

This PR introduces a new configuration parameter `enable_search` in `settings.yaml` and disables the search function by default. 