### PR TITLE
Add Hugo native menu system support

### DIFF
--- a/themes/hugobricks/layouts/baseof.html
+++ b/themes/hugobricks/layouts/baseof.html
@@ -50,6 +50,23 @@
         <div class="nav">
           <nav class="navnav">
             <ul>
+              {{- if .Site.Menus.main -}}
+              {{/* Hugo Native Menu System */}}
+              {{ range .Site.Menus.main }}
+                {{ if not .Parent }}
+                <li class="{{ if eq .URL `/` }}{{ if eq $.RelPermalink `/` }}active{{ end }}{{ else }}{{ if (hasPrefix $.RelPermalink (.URL | relLangURL)) }}active{{ end }}{{ end }}{{ if .HasChildren }} haschildren{{ end }}"><a href="{{ .URL | relLangURL }}" onclick="navClick(event, this);">{{ .Name }}</a>
+                {{ if .HasChildren }}
+                <ul>
+                  {{ range .Children }}
+                      <li class="{{ if hasPrefix $.Page.RelPermalink (.URL | relLangURL) }}active{{ end }}"><a href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
+                  {{ end }}
+                </ul>
+                {{ end }}
+              </li>
+              {{ end }}
+              {{ end }}
+              {{- else -}}
+              {{/* Fallback to Legacy Data Files */}}
               {{ range (index .Site.Data .Language.Lang).header.menuitems }}
                 <li class="{{ if eq .link `/` }}{{ if eq $.RelPermalink `/` }}active{{ end }}{{ else }}{{ if (hasPrefix $.RelPermalink .link) }}active{{ end }}{{ end }}{{ if (index .items 0).title }} haschildren{{ end }}"><a href="{{ .link }}" onclick="navClick(event, this);">{{ .title }}</a>
                   {{ if (index .items 0).title }}
@@ -61,6 +78,7 @@
                   {{ end }}
                 </li>
               {{ end }}
+              {{- end -}}
             </ul>
           </nav>
         </div>
@@ -130,10 +148,18 @@
           </div>
           <div>
             <ul>
+              {{- if .Site.Menus.footer -}}
+              {{/* Hugo Native Footer Menu */}}
+              {{ range .Site.Menus.footer }}
+              <li><a href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
+              {{ end }}
+              {{- else -}}
+              {{/* Fallback to Legacy Data Files */}}
               {{ range (index .Site.Data .Language.Lang).footer.menuitems }}
                 <li><a href="{{ .link }}">{{ .title }}</a></li>
               {{ end }}
-            </ul>  
+              {{- end -}}
+            </ul>
           </div>
           <div>
             {{ partial "socialbuttons.html" . }}


### PR DESCRIPTION
## Summary
- Enable Hugo's native menu system (Site.Menus.main and Site.Menus.footer) alongside existing manual data file approach for better i18n support
- Add support for Site.Menus.main with proper parent-child relationships via .HasChildren and .Children
- Add support for Site.Menus.footer for footer navigation  
- Use relLangURL for language-aware URL generation that works regardless of default language setting
- Maintain full backward compatibility with existing data/<lang>/header.yaml approach

## Benefits
- Better Hugo native i18n support using standard menu configuration
- Language-aware URLs that work regardless of default language setting 
- Proper parent-child menu relationships via Hugo's menu system
- Backward compatible - existing sites continue working unchanged
- Enables proper multilingual navigation without hardcoded URLs

## Usage Example
```yaml
# hugo.yaml
languages:
  en:
    menus:
      main:
        - name: About
          url: /about/
          weight: 10
        - name: Services  
          url: /services/
          weight: 20
        - name: Contact
          url: /contact/
          parent: services
          weight: 21
      footer:
        - name: Privacy
          url: /privacy/
          weight: 10
```

## Implementation
- Templates check for Site.Menus.main/footer first, fall back to legacy data files
- Proper active state detection for both simple and nested menu items
- Full relLangURL usage for multilingual URL support
- Maintains existing CSS classes and structure

## Notice:
- I have changed these things in a website based on your template repo (thanks a lot for it!), it works properly there. Intent there was to get rid of the data/header.yaml files and some fiddling with URLs. 
- I then asked Claude to extract my changes from the original I use to a more anonymized version that might be upstream worthy. Claude appears to have put in these "you may also use the old version" parts, I have entirely removed menu i18n based on the old system.
- Maybe it's useful, maybe it isn't (it is at least for me) so feel free to just close it or tweak it (e.g. by also ripping out the old approach) such that it becomes merge-worthy.
-> 🤖 Generated with [Claude Code](https://claude.ai/code)