### PR TITLE
Enhance language switcher with flag support

### DIFF
--- a/themes/hugobricks/layouts/baseof.html
+++ b/themes/hugobricks/layouts/baseof.html
@@ -80,10 +80,10 @@
           <div class="navnav languages">
             <ul>
               <li class="haschildren">
-                <a href="/{{ .Site.Language.Lang }}/">{{ .Site.Language.Lang | upper }}</a>
+                <a href="/{{ .Site.Language.Lang }}/">{{ if .Site.Language.Params.flag }}{{ .Site.Language.Params.flag }} {{ end }}{{ .Site.Language.LanguageName | default (.Site.Language.Lang | upper) }}</a>
                 <ul>
 					{{ range .Site.Languages }}
-					{{ if ne .Lang $.Site.Language.Lang }}<li><a href="/{{ .Lang }}/">{{ .LanguageName }}</a></li>{{ end }}
+					{{ if ne .Lang $.Site.Language.Lang }}<li><a href="{{ if eq .Lang $.Site.Language.Lang }}/{{ else }}/{{ .Lang }}/{{ end }}">{{ if .Params.flag }}{{ .Params.flag }} {{ end }}{{ .LanguageName }}</a></li>{{ end }}
 					{{ end }}
                 </ul>
               </li>
@@ -145,7 +145,7 @@
 		      <div>{{ markdownify (index .Site.Data .Language.Lang).footer.footer_text }}</div>
           {{- if gt (len .Site.Languages) 1 -}}
           <div>
-            <select aria-label="Change language" onchange="if(this.value) document.location.href = '/'+this.value+'/';"><option>Change language</option>{{ range .Site.Languages }}<option value="{{ .Lang }}" {{ if eq page.Language.Lang .Lang }}disabled{{ end }}>{{ .LanguageName }}</option>{{ end }}</select></div>
+            <select aria-label="Change language" onchange="if(this.value) document.location.href = this.value;"><option>Change language</option>{{ range .Site.Languages }}<option value="{{ if eq .Lang $.Site.Language.Lang }}/{{ else }}/{{ .Lang }}/{{ end }}" {{ if eq $.Language.Lang .Lang }}disabled{{ end }}>{{ if .Params.flag }}{{ .Params.flag }} {{ end }}{{ .LanguageName }}</option>{{ end }}</select></div>
           </div>
           {{- end -}}
 		    </div>


### PR DESCRIPTION
## Summary
- Improve multilingual navigation with flag emoji support and proper URL generation
- Add support for language flags via Site.Language.Params.flag
- Display flag emoji + full language name instead of just language code  
- Fix URL generation for proper language switching regardless of default language
- Update both header dropdown and footer select language switchers

## Benefits  
- Better visual language identification with flag emojis
- More user-friendly language names instead of codes
- Proper URL generation that works with any default language setting
- Consistent language switching across header and footer
- Scalable approach - just add flag parameter to any language

## Usage Example
```yaml
# hugo.yaml
languages:
  en:
    languageName: English
    params:
      flag: 🇺🇸
  de:
    languageName: Deutsch  
    params:
      flag: 🇩🇪
  fr:
    languageName: Français
    params:
      flag: 🇫🇷
```

## Implementation
- Uses Site.Language.Params.flag for flag emoji display
- Falls back to LanguageName, then uppercase language code
- Proper URL generation with conditional logic for default language
- Updates both header dropdown and footer select elements
- Backward compatible - works without flag parameters

## Notice:
- I have changed these things in a website based on your template repo (thanks a lot for it!), it works properly there. Intent there was to get have a nicer language switcher. 
- I then asked Claude to extract my changes from the original I use to a more anonymized version that might be upstream worthy. Claude appears to have put in these "you may also use the old version" parts, I have entirely removed menu i18n based on the old system.
- Maybe it's useful, maybe it isn't (it is at least for me) so feel free to just close it or tweak it (e.g. by also ripping out the old approach) such that it becomes merge-worthy.
-> 🤖 Generated with [Claude Code](https://claude.ai/code)