### PR TITLE
Add centralized social media configuration

### DIFF
--- a/themes/hugobricks/layouts/_partials/socialbuttons.html
+++ b/themes/hugobricks/layouts/_partials/socialbuttons.html
@@ -1,5 +1,13 @@
 <ul class="buttons social">
+    {{- if page.Site.Data.settings.socials -}}
+    {{/* Hugo Centralized Social Media Configuration */}}
+    {{- range page.Site.Data.settings.socials -}}
+    <li><a {{ if eq .name "Mastodon" }}rel="me" {{ end }}href="{{ if .external }}{{ .url | safeURL }}{{ else }}{{ .url | relLangURL }}{{ end }}" class="button icon"><img src="{{ .icon }}" alt="{{ if .external }}{{ .name }}{{ else }}{{ i18n .name }}{{ end }}" /></a></li>
+    {{- end -}}
+    {{- else -}}
+    {{/* Fallback to Legacy Language-Specific Configuration */}}
     {{- range (index page.Site.Data page.Site.Language.Lang).footer.socials -}}
     <li><a href="{{ .link | safeURL }}" class="button icon"><img src="{{ .logo_image }}" alt="{{ .title }}" /></a></li>
+    {{- end -}}
     {{- end -}}
 </ul>


### PR DESCRIPTION
## Summary
- Enable centralized social media management via data/settings.yaml with enhanced external/internal link handling and i18n support
- Add support for Site.Data.settings.socials configuration to reduce duplication across languages
- Enable external/internal URL differentiation with .external flag for proper URL handling
- Use relLangURL for internal links to support proper multilingual URLs
- Add rel="me" attribute for Mastodon links for verification support
- Support i18n translations for social media link labels

## Benefits
- Centralized social media management reduces duplication across language files
- External/internal link differentiation for better URL handling and SEO
- Proper multilingual URL support for internal social links
- Enhanced semantic markup with rel="me" for Mastodon verification
- i18n support for social media link labels
- Backward compatible with existing language-specific configurations

## Usage Example
```yaml
# data/settings.yaml
socials:
  - name: "Mastodon"
    url: "https://mastodon.social/@username"
    icon: "/img/mastodon.svg"  
    external: true
  - name: "contact"
    url: "/contact/"
    icon: "/img/contact.svg"
    external: false
  - name: "GitHub"
    url: "https://github.com/username"
    icon: "/img/github.svg"
    external: true
```

## Implementation
- Templates check for Site.Data.settings.socials first, fall back to language-specific data
- Conditional rel="me" attribute for Mastodon links
- relLangURL for internal links, safeURL for external links
- i18n support for internal link labels
- Maintains existing structure and CSS classes

## Notice:
- I have changed these things in a website based on your template repo (thanks a lot for it!), it works properly there. Intent there was to only have one set of social media channels that would be used for all languages and that would have to changed at only one locations as currently it was per language and then sort-of duplicated across two data files if I remember correctly.
- I then asked Claude to extract my changes from the original I use to a more anonymized version that might be upstream worthy. Claude appears to have put in these "you may also use the old version" parts, I have entirely removed menu i18n based on the old system.
- Maybe it's useful, maybe it isn't (it is at least for me) so feel free to just close it or tweak it (e.g. by also ripping out the old approach) such that it becomes merge-worthy.
-> 🤖 Generated with [Claude Code](https://claude.ai/code)