### PR TITLE
Add i18n function support and centralized data access

### DIFF
--- a/themes/hugobricks/layouts/_partials/contactbuttons.html
+++ b/themes/hugobricks/layouts/_partials/contactbuttons.html
@@ -1,8 +1,12 @@
 <ul class="buttons">
-    {{- if (index page.Site.Data page.Site.Language.Lang).general.contact.phone -}}
+    {{- if page.Site.Data.settings.contact.phone -}}
+        <li><a href="tel:{{ replace page.Site.Data.settings.contact.phone " " "" }}" class="button icon"><img src="/img/phone.svg" alt="{{ page.Site.Data.settings.contact.phone }}" /></a></li>
+    {{- else if (index page.Site.Data page.Site.Language.Lang).general.contact.phone -}}
         <li><a href="tel:{{ replace (index page.Site.Data page.Site.Language.Lang).general.contact.phone " " "" }}" class="button icon"><img src="/img/phone.svg" alt="{{ (index page.Site.Data page.Site.Language.Lang).general.contact.phone }}" /></a></li>
     {{- end -}}
-    {{- if (index page.Site.Data page.Site.Language.Lang).general.contact.email -}}
+    {{- if page.Site.Data.settings.contact.email -}}
+        <li><a href="mailto:{{ page.Site.Data.settings.contact.email }}" class="button icon"><img src="/img/email.svg" alt="{{ page.Site.Data.settings.contact.email }}" /></a></li>
+    {{- else if (index page.Site.Data page.Site.Language.Lang).general.contact.email -}}
         <li><a href="mailto:{{ (index page.Site.Data page.Site.Language.Lang).general.contact.email }}" class="button icon"><img src="/img/email.svg" alt="{{ (index page.Site.Data page.Site.Language.Lang).general.contact.email }}" /></a></li>
     {{- end -}}
 </ul>

--- a/themes/hugobricks/layouts/_partials/footerlogo.html
+++ b/themes/hugobricks/layouts/_partials/footerlogo.html
@@ -4,7 +4,7 @@
 {{- $favicon := .Site.Data.settings.favicon_image -}}
 {{- if .Params.site_favicon_image -}}{{- $favicon = .Params.site_favicon_image -}}{{- end -}}
 
-{{- $title := (index .Site.Data .Language.Lang).general.title -}}
+{{- $title := .Site.Data.settings.title | default (index .Site.Data .Language.Lang).general.title -}}
 {{- if .Params.site_title -}}{{- $title = .Params.site_title -}}{{- end -}}
 
 {{- $subtitle := (index .Site.Data .Language.Lang).header.logo_subtitle -}}
@@ -12,7 +12,7 @@
 
 <a href="{{ relLangURL `/` }}#top" class="logo">
     {{ if $logo }}
-        <img src="{{ $logo }}" alt="{{ (index .Site.Data .Language.Lang).general.title }} logo" />
+        <img src="{{ $logo }}" alt="{{ .Site.Data.settings.title | default (index .Site.Data .Language.Lang).general.title }} logo" />
     {{ else }}
         <div class="{{ if $subtitle }}has_subtitle{{ end}}">
             <img src="{{ $favicon }}" alt="{{ $title }} logo" class="inline black_2_textDark" />
@@ -23,3 +23,8 @@
         </div>
     {{ end }}
 </a>
+{{- if i18n "footer_text" -}}
+<div style="font-size: 0.75rem; font-weight: normal;">{{ markdownify (i18n "footer_text") }}</div>
+{{- else if (index .Site.Data .Language.Lang).footer.footer_text -}}
+<div style="font-size: 0.75rem; font-weight: normal;">{{ markdownify (index .Site.Data .Language.Lang).footer.footer_text }}</div>
+{{- end -}}

--- a/themes/hugobricks/layouts/_partials/logo.html
+++ b/themes/hugobricks/layouts/_partials/logo.html
@@ -4,7 +4,7 @@
 {{- $favicon := .Site.Data.settings.favicon_image -}}
 {{- if .Params.site_favicon_image -}}{{- $favicon = .Params.site_favicon_image -}}{{- end -}}
 
-{{- $title := (index .Site.Data .Language.Lang).general.title -}}
+{{- $title := .Site.Data.settings.title | default (index .Site.Data .Language.Lang).general.title -}}
 {{- if .Params.site_title -}}{{- $title = .Params.site_title -}}{{- end -}}
 
 {{- $subtitle := (index .Site.Data .Language.Lang).header.logo_subtitle -}}
@@ -12,7 +12,7 @@
 
 <a href="{{ relLangURL `/` }}#top" class="logo">
     {{ if $logo }}
-        <img src="{{ $logo }}" alt="{{ (index .Site.Data .Language.Lang).general.title }} logo" />
+        <img src="{{ $logo }}" alt="{{ .Site.Data.settings.title | default (index .Site.Data .Language.Lang).general.title }} logo" />
     {{ else }}
         <div class="{{ if $subtitle }}has_subtitle{{ end}}">
             <img src="{{ $favicon }}" alt="{{ $title }} logo" class="inline black_2_textDark" />


### PR DESCRIPTION
## Summary
- Enable Hugo's native i18n system alongside centralized data configuration for better translation management and data organization
- Add support for {{ i18n "key" }} function calls in footerlogo partial for theme-independent translations
- Enable centralized data access via Site.Data.settings for contact info and titles to reduce duplication
- Maintain backward compatibility with language-specific data files
- Add graceful fallbacks for missing translations or centralized data

## Benefits
- Hugo native i18n support with {{ i18n }} function calls enables theme-independent translations
- Centralized data management reduces duplication across languages
- Backward compatible - existing language-specific configurations continue working
- Better separation of concerns between translatable and non-translatable content
- Enables proper i18n workflows following Hugo best practices

## Usage Examples

**i18n translations:**
```yaml
# i18n/en.yaml
footer_text:
  other: "Copyright © 2024"
secure_contact:
  other: "Secure contact"

# i18n/de.yaml  
footer_text:
  other: "Copyright © 2024"
secure_contact:
  other: "Sicherer Kontakt"
```

**Centralized data:**
```yaml
# data/settings.yaml
title: "My Site"
contact:
  phone: "+1234567890"
  email: "hello@example.com"
```

**Template usage:**
```go
{{ i18n "footer_text" }}              // Uses i18n translations
{{ .Site.Data.settings.title }}       // Uses centralized data
```

## Implementation
- Templates check for i18n translations first, fall back to language-specific data
- Centralized data access with graceful fallbacks
- Maintains all existing CSS classes and structure
- Updates footerlogo, logo, and contactbuttons partials

## Notice:
- I have changed these things in a website based on your template repo (thanks a lot for it!), it works properly there. Intent there was to centralize more common data into a single file and use more of the built-in i18n features where it might make sense.
- I then asked Claude to extract my changes from the original I use to a more anonymized version that might be upstream worthy. Claude appears to have put in these "you may also use the old version" parts, I have entirely removed menu i18n based on the old system.
- Maybe it's useful, maybe it isn't (it is at least for me) so feel free to just close it or tweak it (e.g. by also ripping out the old approach) such that it becomes merge-worthy.
-> 🤖 Generated with [Claude Code](https://claude.ai/code)