### PR TITLE
Added browser caching for svg files same as for other image files

### DIFF
--- a/themes/hugobricks/static/.htaccess
+++ b/themes/hugobricks/static/.htaccess
@@ -30,6 +30,7 @@ ExpiresByType image/png "access plus 1 month"
 ExpiresByType image/jpg "access plus 1 month"
 ExpiresByType image/jpeg "access plus 1 month"
 ExpiresByType image/webp "access plus 1 month"
+ExpiresByType image/svg "access plus 1 month"
 # Javascript
 ExpiresByType text/javascript "access plus 1 month"
 </IfModule>


### PR DESCRIPTION
Currently, most images are cached for one month. But SVG images are not. This will also enable caching for SVG images.