### PR TITLE
Made generated website change less

### DIFF
--- a/themes/hugobricks/layouts/baseof.html
+++ b/themes/hugobricks/layouts/baseof.html
@@ -12,7 +12,7 @@
     {{- $color := "style" -}}
     {{- if .Params.color_name -}}{{- $color = .Params.color_name -}}{{- end -}}
     {{- if .Site.Data.settings.color_name -}}{{- $color = .Site.Data.settings.color_name -}}{{- end -}}
-    <link href="/css/{{ $color }}.css?version={{ now }}" rel="stylesheet">
+    <link href="{{ (resources.Get (printf "/css/%s.css" $color) | resources.Fingerprint "md5").RelPermalink }}" rel="stylesheet">
 
   </head>
   <body id="top" class="{{ if in (substr .Content  0 100) `transparent_header` }}transparent_header{{ end }} filename_{{ with .File }}{{ .BaseFileName }}{{ end }}">


### PR DESCRIPTION
Currently, the generated website changes whenever it is built. This is because the included css is being added with a timestamp of the generation time. This pull request will change this to being a MD5 hash over the CSS file (which does not change if the CSS does not change). This leads to a better comparable and reproducible build of the page.