### PR TITLE
Added a place (partial) to add custom headers

### DIFF
--- a/themes/hugobricks/layouts/_partials/header.html
+++ b/themes/hugobricks/layouts/_partials/header.html
@@ -1,0 +1,1 @@
+<!-- Add custom header here -->

--- a/themes/hugobricks/layouts/_partials/page-end.html
+++ b/themes/hugobricks/layouts/_partials/page-end.html
@@ -1,0 +1,1 @@
+<!-- Add custom code to put at the bottom of the HTML -->

--- a/themes/hugobricks/layouts/baseof.html
+++ b/themes/hugobricks/layouts/baseof.html
@@ -14,6 +14,7 @@
     {{- if .Site.Data.settings.color_name -}}{{- $color = .Site.Data.settings.color_name -}}{{- end -}}
     <link href="/css/{{ $color }}.css?version={{ now }}" rel="stylesheet">
 
+    {{ partial "header.html" . }}
   </head>
   <body id="top" class="{{ if in (substr .Content  0 100) `transparent_header` }}transparent_header{{ end }} filename_{{ with .File }}{{ .BaseFileName }}{{ end }}">
     <script>      

--- a/themes/hugobricks/layouts/baseof.html
+++ b/themes/hugobricks/layouts/baseof.html
@@ -174,7 +174,8 @@
       populateCart();
     </script>
     {{- end -}}
+    {{ partial "page-end.html" . }}
 
-      </div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
With this pull request, users can overwrite the headers.html partial in their site to add their custom headers in the generated HTML files. This is a place to e.g. add Matomo user tracking. Currently one has to overwrite the whole baseof.html to achieve the same.